### PR TITLE
Remove explicit permissions on file open.

### DIFF
--- a/src/mapped_file.cpp
+++ b/src/mapped_file.cpp
@@ -261,7 +261,7 @@ void mapped_file_impl::open_file(param_type p)
         flags |= O_LARGEFILE;
     #endif
     errno = 0;
-    handle_ = ::open(p.path.c_str(), flags, S_IRWXU);
+    handle_ = ::open(p.path.c_str(), flags, S_IRWXU | S_IRWXG | S_IRWXO);
     if (errno != 0)
         cleanup_and_throw("failed opening file");
 


### PR DESCRIPTION
In mapped_file, there are explicity S_IRWXU permissions on file open. This ignores umask and that can produce an unexpected 700 permission on files created via mapped files.

https://svn.boost.org/trac/boost/ticket/7273
