### PR TITLE
Remove misleading comment

### DIFF
--- a/include/boost/iostreams/detail/config/unreachable_return.hpp
+++ b/include/boost/iostreams/detail/config/unreachable_return.hpp
@@ -13,7 +13,6 @@
 
 #include <boost/config.hpp>
 
-// If Boost.Exception has BOOST_ATTRIBUTE_NORETURN
 #if defined(_MSC_VER) || defined(__GNUC__)
 #define BOOST_IOSTREAMS_UNREACHABLE_RETURN(x) \
     BOOST_UNREACHABLE_RETURN(x)


### PR DESCRIPTION
Remove misleading comment about Boost.Exception.
