### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/file_descriptor.cpp
+++ b/src/file_descriptor.cpp
@@ -265,7 +265,7 @@ std::streamsize file_descriptor_impl::read(char* s, std::streamsize n)
 {
 #ifdef BOOST_IOSTREAMS_WINDOWS
     DWORD result;
-    if (!::ReadFile(handle_, s, n, &result, NULL))
+    if (!::ReadFile(handle_, s, static_cast<DWORD>(n), &result, NULL))
     {
         // report EOF if the write-side of a pipe has been closed
         if (GetLastError() == ERROR_BROKEN_PIPE)
@@ -289,7 +289,7 @@ std::streamsize file_descriptor_impl::write(const char* s, std::streamsize n)
 {
 #ifdef BOOST_IOSTREAMS_WINDOWS
     DWORD ignore;
-    if (!::WriteFile(handle_, s, n, &ignore, NULL))
+    if (!::WriteFile(handle_, s, static_cast<DWORD>(n), &ignore, NULL))
         throw_system_failure("failed writing");
     return n;
 #else // #ifdef BOOST_IOSTREAMS_WINDOWS

--- a/test/detail/verification.hpp
+++ b/test/detail/verification.hpp
@@ -72,7 +72,7 @@ bool compare_streams_in_chunks(BOOST_ISTREAM& first, BOOST_ISTREAM& second)
         std::streamsize amt = first.gcount();
         if ( amt != static_cast<std::streamsize>(second.gcount()) ||
              BOOST_IOSTREAMS_CHAR_TRAITS(BOOST_CHAR)::
-                compare(buf_one, buf_two, amt) != 0 )
+                compare(buf_one, buf_two, static_cast<std::size_t>(amt)) != 0 )
             return false;
         ++i;
     } while (!first.eof());

--- a/test/read_input_istream_test.hpp
+++ b/test/read_input_istream_test.hpp
@@ -21,8 +21,7 @@ void read_input_istream_test()
     using namespace boost::iostreams;
     using namespace boost::iostreams::test;
 
-    test_file test;      
-    test_file test2;
+    test_file test;
 
     {
         test_file test2;


### PR DESCRIPTION
- silenced narrowing conversion warnings with explicit casts
- fixed a variable shadowing warning by removing an unused variable
