### PR TITLE
#10072. Fixed filtering_stream::size() is not const.

### DIFF
--- a/include/boost/iostreams/chain.hpp
+++ b/include/boost/iostreams/chain.hpp
@@ -472,7 +472,7 @@ public:
     BOOST_IOSTREAMS_DEFINE_PUSH(push, mode, char_type, push_impl)
     void pop() { chain_->pop(); }
     bool empty() const { return chain_->empty(); }
-    size_type size() { return chain_->size(); }
+    size_type size() const { return chain_->size(); }
     void reset() { chain_->reset(); }
 
     // Returns a copy of the underlying chain.


### PR DESCRIPTION
- Some of the functionality including size() have been moved to class chain_client in chain.hpp hence the fix in chain.hpp
