### PR TITLE
fix shadow warnings from clang trunk

### DIFF
--- a/include/boost/iostreams/filter/bzip2.hpp
+++ b/include/boost/iostreams/filter/bzip2.hpp
@@ -87,9 +87,9 @@ const bool default_small       = false;
 struct bzip2_params {
 
     // Non-explicit constructor for compression.
-    bzip2_params( int block_size   = bzip2::default_block_size,
-                  int work_factor  = bzip2::default_work_factor )
-        : block_size(block_size), work_factor(work_factor)
+    bzip2_params( int block_size_  = bzip2::default_block_size,
+                  int work_factor_ = bzip2::default_work_factor )
+        : block_size(block_size_), work_factor(work_factor_)
         { }
 
     // Constructor for decompression.

--- a/include/boost/iostreams/filter/gzip.hpp
+++ b/include/boost/iostreams/filter/gzip.hpp
@@ -143,11 +143,11 @@ struct gzip_params : zlib_params {
                  int window_bits        = gzip::default_window_bits,
                  int mem_level          = gzip::default_mem_level,
                  int strategy           = gzip::default_strategy,
-                 std::string file_name  = "",
-                 std::string comment    = "",
-                 std::time_t mtime      = 0 )
+                 std::string file_name_  = "",
+                 std::string comment_    = "",
+                 std::time_t mtime_      = 0 )
         : zlib_params(level, method, window_bits, mem_level, strategy),
-          file_name(file_name), comment(comment), mtime(mtime)
+          file_name(file_name_), comment(comment_), mtime(mtime_)
         { }
     std::string  file_name;
     std::string  comment;
@@ -505,7 +505,7 @@ public:
                 if (footer_.done()) {
                     if (footer_.crc() != this->crc())
                         boost::throw_exception(gzip_error(gzip::bad_crc));
-                    int c = boost::iostreams::get(peek);
+                    c = boost::iostreams::get(peek);
                     if (traits_type::is_eof(c)) {
                         state_ = s_done;
                     } else {

--- a/include/boost/iostreams/filter/zlib.hpp
+++ b/include/boost/iostreams/filter/zlib.hpp
@@ -110,16 +110,16 @@ const bool default_noheader                  = false;
 struct zlib_params {
 
     // Non-explicit constructor.
-    zlib_params( int level           = zlib::default_compression,
-                 int method          = zlib::deflated,
-                 int window_bits     = zlib::default_window_bits, 
-                 int mem_level       = zlib::default_mem_level, 
-                 int strategy        = zlib::default_strategy,
-                 bool noheader       = zlib::default_noheader,
-                 bool calculate_crc  = zlib::default_crc )
-        : level(level), method(method), window_bits(window_bits),
-          mem_level(mem_level), strategy(strategy),  
-          noheader(noheader), calculate_crc(calculate_crc)
+    zlib_params( int level_          = zlib::default_compression,
+                 int method_         = zlib::deflated,
+                 int window_bits_    = zlib::default_window_bits, 
+                 int mem_level_      = zlib::default_mem_level, 
+                 int strategy_       = zlib::default_strategy,
+                 bool noheader_      = zlib::default_noheader,
+                 bool calculate_crc_ = zlib::default_crc )
+        : level(level_), method(method_), window_bits(window_bits_),
+          mem_level(mem_level_), strategy(strategy_),  
+          noheader(noheader_), calculate_crc(calculate_crc_)
         { }
     int level;
     int method;


### PR DESCRIPTION
This patch renames some constructor parameters to avoid shadow warning.
