### PR TITLE
if a file does not exist and BOOST_IOS::app specified, file_descriptor should create the file

### DIFF
--- a/src/file_descriptor.cpp
+++ b/src/file_descriptor.cpp
@@ -202,10 +202,10 @@ void file_descriptor_impl::open(const detail::path& p, BOOST_IOS::openmode mode)
             (BOOST_IOS::app | BOOST_IOS::trunc) )
             boost::throw_exception(BOOST_IOSTREAMS_FAILURE("bad open mode"));
         oflag |= O_WRONLY;
+        oflag |= O_CREAT;
         if (mode & BOOST_IOS::app)
             oflag |= O_APPEND;
         else {
-            oflag |= O_CREAT;
             oflag |= O_TRUNC; 
         }
     } else {


### PR DESCRIPTION
file_descriptor should handle file open mode according to generally accepted convention and uniformly on all platforms:

if both BOOST_IOS::out and BOOST_IOS::app specified, the class must create the file if it doesn't exist (just as it's done in Windows implementation).
