### PR TITLE
Correct spelling of "suppress"

### DIFF
--- a/test/detail/operation_sequence.hpp
+++ b/test/detail/operation_sequence.hpp
@@ -63,7 +63,7 @@ private:
             : seq(seq), id(id), error_code(error_code)
             { }
         ~impl() { remove_operation(seq, id); }
-        impl& operator=(const impl&); // Supress VC warning 4512
+        impl& operator=(const impl&); // Suppress VC warning 4512
         operation_sequence&  seq;
         int                  id;
         int                  error_code;


### PR DESCRIPTION
"Suppress" is spelled with two P's, even in British English.