### PR TITLE
Included VxWorks as one of the platforms that do not use Dinkumware Standard Library

### DIFF
--- a/include/boost/iostreams/detail/config/fpos.hpp
+++ b/include/boost/iostreams/detail/config/fpos.hpp
@@ -23,7 +23,7 @@
 #endif
 
 # if (defined(_YVALS) || defined(_CPPLIB_VER)) && !defined(__SGI_STL_PORT) && \
-     !defined(_STLPORT_VERSION) && !defined(__QNX__)
+     !defined(_STLPORT_VERSION) && !defined(__QNX__) && !defined(_VX_CPU)
      /**/
 #  define BOOST_IOSTREAMS_HAS_DINKUMWARE_FPOS
 # endif


### PR DESCRIPTION
Included VxWorks as one of the platforms that do not use std::fpos from the Dinkumware Standard Library. This will allow it to compile properly on VxWorks.
