### PR TITLE
Fixed issue #5237.

### DIFF
--- a/include/boost/iostreams/filter/gzip.hpp
+++ b/include/boost/iostreams/filter/gzip.hpp
@@ -248,6 +248,8 @@ public:
     void close(Sink& snk, BOOST_IOS::openmode m)
     {
         try {
+            if (!(flags_ & f_header_done))
+                write(snk, 0, 0);
             // Close zlib compressor.
             base_type::close(snk, m);
 


### PR DESCRIPTION
Ticket [#5273](https://svn.boost.org/trac/boost/ticket/5237) in Boost's Trac issue-system describes the following error:

Writing gzipped files with no content results in corrupted files being created which are no valid gzip-files.

This pull-request solves this problem by applying the (very simple) patch described in [this comment](https://svn.boost.org/trac/boost/ticket/5237#comment:4) to the ticket.
