### PR TITLE
Ticket #11752. Modified return status to return -1

### DIFF
--- a/include/boost/iostreams/device/null.hpp
+++ b/include/boost/iostreams/device/null.hpp
@@ -29,7 +29,7 @@ public:
           public device_tag,
           public closable_tag
         { };
-    std::streamsize read(Ch*, std::streamsize) { return 0; }
+    std::streamsize read(Ch*, std::streamsize) { return -1; }
     std::streamsize write(const Ch*, std::streamsize n) { return n; }
     std::streampos seek( stream_offset, BOOST_IOS::seekdir,
                          BOOST_IOS::openmode = 


### PR DESCRIPTION
basic_null_device::read returns 0 but -1 is expected.
Modified return status to -1.
