### PR TITLE
Do not check length_ before computing CRC.

### DIFF
--- a/src/zlib.cpp
+++ b/src/zlib.cpp
@@ -120,8 +120,7 @@ void zlib_base::after(const char*& src_begin, char*& dest_begin, bool compress)
         zlib::uint length = compress ?
             static_cast<zlib::uint>(next_in - src_begin) :
             static_cast<zlib::uint>(next_out - dest_begin);
-        if (length > 0)
-            crc_ = crc_imp_ = crc32(crc_imp_, buf, length);
+        crc_ = crc_imp_ = crc32(crc_imp_, buf, length);
     }
     total_in_ = s->total_in;
     total_out_ = s->total_out;


### PR DESCRIPTION
This fixes a problem where the gzip_decompressor would fail the CRC
check when reading a multipart gzip file that had been written using
Z_FULL_FLUSH, and contains an empty part (with a 0 CRC).

Including a unit test that exposes the bug.
