### PR TITLE
Undocument ZLIB_* BZIP2_* deleted b2 variables

### DIFF
--- a/doc/installation.html
+++ b/doc/installation.html
@@ -101,67 +101,11 @@
     <TD><CODE>1</CODE> (Windows)</TD>
 </TR>
 <TR>
-    <TD><CODE>BZIP2_BINARY</CODE></TD>
-    <TD>
-        Name of the libbz2 binary, not including the file extension, or the "lib" prefix on UNIX. On Windows, if linking with a dynamic build of libbz2, specify the name of the import library.
-    </TD>
-    <TD><CODE>bz2</CODE>&nbsp;(UNIX)<BR><CODE>libbz2</CODE>&nbsp;(Windows)</TD>
-</TR>
-<TR>
-    <TD><CODE>BZIP2_INCLUDE</CODE></TD>
-    <TD>
-        Path to the libbz2 headers, if they're not in a location where they'll be found automatically.
-    </TD>
-    <TD><CODE>BZIP2_SOURCE</CODE></TD>
-</TR>
-<TR>
-    <TD><CODE>BZIP2_LIBPATH</CODE></TD>
-    <TD>
-        Path to the libbz2 binary, if it's not in a location where it will be found automatically. On Windows, if linking with a dynamic build of libbz2, specify the path to the import library.
-    </TD>
-    <TD ALIGN="center">-</TD>
-</TR>
-<TR>
-    <TD><CODE>BZIP2_SOURCE</CODE></TD>
-    <TD>
-        Path to the libbz2 source files, if they're not in a location where they'll be found automatically.
-    </TD>
-    <TD ALIGN="center">-</TD>
-</TR>
-<TR>
     <TD><CODE>NO_ZLIB</CODE></TD>
     <TD>
         Disable support for the zlib filters.
     </TD>
     <TD><CODE>1</CODE> (Windows)</TD>
-</TR>
-<TR>
-    <TD><CODE>ZLIB_BINARY</CODE></TD>
-    <TD>
-        Name of the zlib binary, not including the file extension, or the "lib" prefix on UNIX. On Windows, if linking with a dynamic build of zlib, specify the name of the import library.
-    </TD>
-    <TD><CODE>z</CODE>&nbsp;(UNIX)<BR><CODE>zdll</CODE>&nbsp;(Windows)</TD>
-</TR>
-<TR>
-    <TD><CODE>ZLIB_INCLUDE</CODE></TD>
-    <TD>
-        Path to the zlib headers, if they're not in a location where they'll be found automatically.
-    </TD>
-    <TD><CODE>ZLIB_SOURCE</CODE></TD>
-</TR>
-<TR>
-    <TD><CODE>ZLIB_LIBPATH</CODE></TD>
-    <TD>
-        Path to the zlib binary, if it's not in a location where it will be found automatically. On Windows, if linking with a dynamic build of zlib, specify the path to the import library.
-    </TD>
-    <TD ALIGN="center">-</TD>
-</TR>
-<TR>
-    <TD><CODE>ZLIB_SOURCE</CODE></TD>
-    <TD>
-        Path to the zlib source files, if they're not in a location where they'll be found automatically.
-    </TD>
-    <TD ALIGN="center">-</TD>
 </TR>
 </TABLE>
 


### PR DESCRIPTION
Removed at 08798f6.
Question: how to configure with zlib support, see https://svn.boost.org/trac/boost/ticket/12505.
