### PR TITLE
Fix hidden visibility symbols for mac/clang

### DIFF
--- a/include/boost/iostreams/detail/config/dyn_link.hpp
+++ b/include/boost/iostreams/detail/config/dyn_link.hpp
@@ -27,7 +27,16 @@
 #  else
 #   define BOOST_IOSTREAMS_DECL __declspec(dllimport)
 #  endif  
-# endif  
+# endif
+//--------------Enable dynamic linking for non-windows---------------------//
+#else // BOOST_HAS_DECLSPEC
+# if defined(BOOST_ALL_DYN_LINK) || defined(BOOST_IOSTREAMS_DYN_LINK)
+#  ifdef BOOST_IOSTREAMS_SOURCE
+#   define BOOST_IOSTREAMS_DECL BOOST_SYMBOL_EXPORT
+#  else
+#   define BOOST_IOSTREAMS_DECL BOOST_SYMBOL_IMPORT
+#  endif
+# endif
 #endif 
 
 #ifndef BOOST_IOSTREAMS_DECL


### PR DESCRIPTION
The symbol visibility settings are only set for Win/gcc builds. Added equivalent instructions that will work for Mac OS/Clang builds. This is similar to what was done in the config files of the other Boost libraries.