### PR TITLE
Silence signedness warning in clang

### DIFF
--- a/include/boost/iostreams/filter/gzip.hpp
+++ b/include/boost/iostreams/filter/gzip.hpp
@@ -671,7 +671,7 @@ basic_gzip_compressor<Alloc>::basic_gzip_compressor
               0 );
     header_.reserve(length);
     header_ += gzip::magic::id1;                         // ID1.
-    header_ += gzip::magic::id2;                         // ID2.
+    header_ += static_cast<char>(gzip::magic::id2);      // ID2.
     header_ += gzip::method::deflate;                    // CM.
     header_ += static_cast<char>(flags);                 // FLG.
     header_ += static_cast<char>(0xFF & p.mtime);        // MTIME.


### PR DESCRIPTION
`warning: implicit conversion from 'const int' to 'char' changes value from 139 to -117 [-Wconstant-conversion]`