### PR TITLE
gzip: Add cast to avoid compiler warning.

### DIFF
--- a/include/boost/iostreams/filter/gzip.hpp
+++ b/include/boost/iostreams/filter/gzip.hpp
@@ -671,7 +671,7 @@ basic_gzip_compressor<Alloc>::basic_gzip_compressor
               0 );
     header_.reserve(length);
     header_ += gzip::magic::id1;                         // ID1.
-    header_ += gzip::magic::id2;                         // ID2.
+    header_ += static_cast<char>(gzip::magic::id2);      // ID2.
     header_ += gzip::method::deflate;                    // CM.
     header_ += static_cast<char>(flags);                 // FLG.
     header_ += static_cast<char>(0xFF & p.mtime);        // MTIME.


### PR DESCRIPTION
Avoids:
warning: overflow in implicit constant conversion

Ideally the casts should be completely avoided, since when char is
signed, half of them including this one actually trigger undefined
behaviour, i.e. this code is very broken, but there doesn't seem to
be an easy fix for that.