### PR TITLE
Update cpp files for removed MSVC workarounds.

### DIFF
--- a/src/bzip2.cpp
+++ b/src/bzip2.cpp
@@ -135,23 +135,18 @@ int bzip2_base::decompress()
 
 void bzip2_base::do_init
     ( bool compress, 
-      #if !BOOST_WORKAROUND(BOOST_MSVC, < 1300)
-          bzip2::alloc_func /* alloc */, 
-          bzip2::free_func /* free */, 
-      #endif
+      bzip2::alloc_func /* alloc */, 
+      bzip2::free_func /* free */, 
       void* derived )
 {
     bz_stream* s = static_cast<bz_stream*>(stream_);
 
     // Current interface for customizing memory management 
     // is non-conforming and has been disabled:
-    //#if !BOOST_WORKAROUND(BOOST_MSVC, < 1300)
     //    s->bzalloc = alloc;
     //    s->bzfree = free;
-    //#else
         s->bzalloc = 0;
         s->bzfree = 0;
-    //#endif
     s->opaque = derived;
     bzip2_error::check BOOST_PREVENT_MACRO_SUBSTITUTION( 
         compress ?

--- a/src/zlib.cpp
+++ b/src/zlib.cpp
@@ -154,9 +154,7 @@ void zlib_base::reset(bool compress, bool realloc)
 
 void zlib_base::do_init
     ( const zlib_params& p, bool compress, 
-      #if !BOOST_WORKAROUND(BOOST_MSVC, < 1300)
-          zlib::xalloc_func /* alloc */, zlib::xfree_func /* free*/, 
-      #endif
+      zlib::xalloc_func /* alloc */, zlib::xfree_func /* free*/, 
       void* derived )
 {
     calculate_crc_ = p.calculate_crc;
@@ -164,13 +162,10 @@ void zlib_base::do_init
 
     // Current interface for customizing memory management 
     // is non-conforming and has been disabled:
-    //#if !BOOST_WORKAROUND(BOOST_MSVC, < 1300)
     //    s->zalloc = alloc;
     //    s->zfree = free;
-    //#else
         s->zalloc = 0;
         s->zfree = 0;
-    //#endif
     s->opaque = derived;
     int window_bits = p.noheader? -p.window_bits : p.window_bits;
     zlib_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(


### PR DESCRIPTION
5c9bde1d0a6460f03f10b3e203057d525f09745c forgot to also update
the .cpp files.