### PR TITLE
Clarify origin and authors of recently added files.

### DIFF
--- a/include/boost/iostreams/filter/lzma.hpp
+++ b/include/boost/iostreams/filter/lzma.hpp
@@ -1,4 +1,5 @@
 // (C) Copyright Milan Svoboda 2008.
+// Originally developed under the fusecompress project.
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt.)
 

--- a/src/lzma.cpp
+++ b/src/lzma.cpp
@@ -1,3 +1,6 @@
+// (C) Copyright Milan Svoboda 2008.
+// Originally developed under the fusecompress project.
+// Based on bzip2.cpp by:
 // (C) Copyright Jonathan Turkanis 2003.
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt.)

--- a/test/lzma_test.cpp
+++ b/test/lzma_test.cpp
@@ -1,4 +1,5 @@
 // (C) COPYRIGHT 2017 ARM Limited
+// Based on gzip_test.cpp by:
 // (C) Copyright 2008 CodeRage, LLC (turkanis at coderage dot com)
 // (C) Copyright 2004-2007 Jonathan Turkanis
 // Distributed under the Boost Software License, Version 1.0. (See accompanying


### PR DESCRIPTION
As git history isn't useful in this case, it might be good
to add more details in the header instead.

As mentioned in https://github.com/boostorg/iostreams/pull/38.
Honestly no idea this is best-practice, but it seems to me to clarify things while still keeping all possibly applicable copyright notices intact. 