### PR TITLE
Fix C4250 warning because of VS2012 CRT

### DIFF
--- a/include/boost/iostreams/stream.hpp
+++ b/include/boost/iostreams/stream.hpp
@@ -56,6 +56,12 @@ struct stream_traits {
             >::type stream_tag;
 };
 
+#if defined(_MSC_VER) && (_MSC_VER == 1700)
+# pragma warning(push)
+// https://connect.microsoft.com/VisualStudio/feedback/details/733720/
+# pragma warning(disable: 4250)
+#endif
+
 // By encapsulating initialization in a base, we can define the macro
 // BOOST_IOSTREAMS_DEFINE_FORWARDING_FUNCTIONS to generate constructors
 // without base member initializer lists.
@@ -84,6 +90,10 @@ public:
     stream_base() : pbase_type(), stream_type(&member) { }
 };
 
+#if defined(_MSC_VER) && (_MSC_VER == 1700)
+# pragma warning(pop)
+#endif
+
 } } } // End namespaces detail, iostreams, boost.
 
 #ifdef BOOST_IOSTREAMS_BROKEN_OVERLOAD_RESOLUTION
@@ -91,6 +101,12 @@ public:
 #else
 
 namespace boost { namespace iostreams {
+
+#if defined(_MSC_VER) && (_MSC_VER == 1700)
+# pragma warning(push)
+// https://connect.microsoft.com/VisualStudio/feedback/details/733720/
+# pragma warning(disable: 4250)
+#endif
 
 //
 // Template name: stream.
@@ -143,6 +159,10 @@ private:
         this->member.open(dev BOOST_IOSTREAMS_PUSH_ARGS()); 
     }
 };
+
+#if defined(_MSC_VER) && (_MSC_VER == 1700)
+# pragma warning(pop)
+#endif
 
 } } // End namespaces iostreams, boost.
 


### PR DESCRIPTION
The workaround in VC++ CRT of MSVC compiler bug leads to the fact that if your class inherits from std streams you will get C4250 warning. (https://connect.microsoft.com/VisualStudio/feedback/details/733720/)

```
..\..\..\..\boost/iostreams/stream.hpp(145) : warning C4250: 'boost::iostreams::stream<Device>' : inherits 'std::basic_istream<_Elem,_Traits>::std::basic_istream<_Elem,_Traits>::_Add_vtordisp1' via dominance
..\..\..\..\boost/iostreams/stream.hpp(145) : warning C4250: 'boost::iostreams::stream<Device>' : inherits 'std::basic_ostream<_Elem,_Traits>::std::basic_ostream<_Elem,_Traits>::_Add_vtordisp2' via dominance
```

If you are not fine with this fix, will it be okay to suppress it like that https://github.com/Kojoley/iostreams/commit/ba61a0c1c376e89617a09ff171964a317bb7f236?