### PR TITLE
Most members of std::allocate are deprecated in C++17

### DIFF
--- a/include/boost/iostreams/detail/buffer.hpp
+++ b/include/boost/iostreams/detail/buffer.hpp
@@ -43,10 +43,12 @@ private:
     typedef typename Alloc::template rebind<Ch>::other allocator_type;
 #else
     typedef typename std::allocator_traits<Alloc>::template rebind_alloc<Ch> allocator_type;
+    typedef std::allocator_traits<allocator_type> allocator_traits;
 #endif
 #else
     typedef std::allocator<Ch> allocator_type;
 #endif
+    static Ch* allocate(std::streamsize buffer_size);
 public:
     basic_buffer();
     basic_buffer(std::streamsize buffer_size);
@@ -149,9 +151,21 @@ template<typename Ch, typename Alloc>
 basic_buffer<Ch, Alloc>::basic_buffer() : buf_(0), size_(0) { }
 
 template<typename Ch, typename Alloc>
+inline Ch* basic_buffer<Ch, Alloc>::allocate(std::streamsize buffer_size)
+{
+#if defined(BOOST_NO_CXX11_ALLOCATOR) || defined(BOOST_NO_STD_ALLOCATOR)
+    return static_cast<Ch*>(allocator_type().allocate(
+           static_cast<BOOST_DEDUCED_TYPENAME Alloc::size_type>(buffer_size), 0));
+#else
+    allocator_type alloc;
+    return static_cast<Ch*>(allocator_traits::allocate(alloc,
+           static_cast<BOOST_DEDUCED_TYPENAME allocator_traits::size_type>(buffer_size)));
+#endif
+}
+
+template<typename Ch, typename Alloc>
 basic_buffer<Ch, Alloc>::basic_buffer(std::streamsize buffer_size)
-    : buf_(static_cast<Ch*>(allocator_type().allocate(
-           static_cast<BOOST_DEDUCED_TYPENAME Alloc::size_type>(buffer_size), 0))), 
+    : buf_(allocate(buffer_size)),
       size_(buffer_size) // Cast for SunPro 5.3.
     { }
 
@@ -159,8 +173,14 @@ template<typename Ch, typename Alloc>
 inline basic_buffer<Ch, Alloc>::~basic_buffer()
 {
     if (buf_) {
+#if defined(BOOST_NO_CXX11_ALLOCATOR) || defined(BOOST_NO_STD_ALLOCATOR)
         allocator_type().deallocate(buf_,
             static_cast<BOOST_DEDUCED_TYPENAME Alloc::size_type>(size_));
+#else
+        allocator_type alloc;
+        allocator_traits::deallocate(alloc, buf_,
+            static_cast<BOOST_DEDUCED_TYPENAME allocator_traits::size_type>(size_));
+#endif
     }
 }
 

--- a/include/boost/iostreams/filter/bzip2.hpp
+++ b/include/boost/iostreams/filter/bzip2.hpp
@@ -138,7 +138,11 @@ template< typename Alloc,
               BOOST_DEDUCED_TYPENAME bzip2_allocator_traits<Alloc>::type >
 struct bzip2_allocator : private Base {
 private:
+#if defined(BOOST_NO_CXX11_ALLOCATOR) || defined(BOOST_NO_STD_ALLOCATOR)
     typedef typename Base::size_type size_type;
+#else
+    typedef typename std::allocator_traits<Base>::size_type size_type;
+#endif
 public:
     BOOST_STATIC_CONSTANT(bool, custom = 
         (!is_same<std::allocator<char>, Base>::value));

--- a/include/boost/iostreams/filter/lzma.hpp
+++ b/include/boost/iostreams/filter/lzma.hpp
@@ -127,7 +127,11 @@ template< typename Alloc,
               BOOST_DEDUCED_TYPENAME lzma_allocator_traits<Alloc>::type >
 struct lzma_allocator : private Base {
 private:
+#if defined(BOOST_NO_CXX11_ALLOCATOR) || defined(BOOST_NO_STD_ALLOCATOR)
     typedef typename Base::size_type size_type;
+#else
+    typedef typename std::allocator_traits<Base>::size_type size_type;
+#endif
 public:
     BOOST_STATIC_CONSTANT(bool, custom =
         (!is_same<std::allocator<char>, Base>::value));

--- a/include/boost/iostreams/filter/zlib.hpp
+++ b/include/boost/iostreams/filter/zlib.hpp
@@ -164,7 +164,11 @@ template< typename Alloc,
               BOOST_DEDUCED_TYPENAME zlib_allocator_traits<Alloc>::type >
 struct zlib_allocator : private Base {
 private:
+#if defined(BOOST_NO_CXX11_ALLOCATOR) || defined(BOOST_NO_STD_ALLOCATOR)
     typedef typename Base::size_type size_type;
+#else
+    typedef typename std::allocator_traits<Base>::size_type size_type;
+#endif
 public:
     BOOST_STATIC_CONSTANT(bool, custom = 
         (!is_same<std::allocator<char>, Base>::value));


### PR DESCRIPTION
Replace them by their cousins from std::allocator_traits.

Signed-off-by: Daniela Engert <dani@ngrt.de>