### PR TITLE
VxWorks' Dinkum clib does not support the fpos extension

### DIFF
--- a/include/boost/iostreams/detail/config/fpos.hpp
+++ b/include/boost/iostreams/detail/config/fpos.hpp
@@ -25,7 +25,7 @@
 #include <boost/config.hpp>
 
 # if (defined(_YVALS) || defined(_CPPLIB_VER)) && !defined(__SGI_STL_PORT) && \
-     !defined(_STLPORT_VERSION) && !defined(__QNX__) && !defined(_VX_CPU)
+     !defined(_STLPORT_VERSION) && !defined(__QNX__) && !defined(_VX_CPU) && !defined(__VXWORKS__)
      /**/
      
 #include <boost/iostreams/detail/ios.hpp>


### PR DESCRIPTION
The Dinkum code base that's distributed with VxWorks and QNX  is slightly different than Windows and this seems to be one of the differences.