### PR TITLE
Non-blocking adapter write() consistent with read().

### DIFF
--- a/include/boost/iostreams/detail/adapter/non_blocking_adapter.hpp
+++ b/include/boost/iostreams/detail/adapter/non_blocking_adapter.hpp
@@ -46,7 +46,7 @@ public:
                 break;
             result += amt;
         }
-        return result;    
+        return result != 0 ? result : -1;
     }
     std::streampos seek( stream_offset off, BOOST_IOS::seekdir way,
                          BOOST_IOS::openmode which = 


### PR DESCRIPTION
Same behavior for when nothing was written as read().