### PR TITLE
Turn off BOOST_IOSTREAMS_HAS_DINKUMWARE_FPOS for MSVC++

### DIFF
--- a/include/boost/iostreams/detail/config/fpos.hpp
+++ b/include/boost/iostreams/detail/config/fpos.hpp
@@ -1,7 +1,7 @@
 /*
- * Distributed under the Boost Software License, Version 1.0.(See accompanying 
+ * Distributed under the Boost Software License, Version 1.0.(See accompanying
  * file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt.)
- * 
+ *
  * See http://www.boost.org/libs/iostreams for documentation.
 
  * File:        boost/iostreams/detail/execute.hpp
@@ -11,7 +11,7 @@
  * Contact:     turkanis at coderage dot com
  *
  * Defines the preprocessor symbol BOOST_IOSTREAMS_HAS_DINKUMWARE_FPOS for
- * platforms that use the implementation of std::fpos from the Dinkumware 
+ * platforms that use the implementation of std::fpos from the Dinkumware
  * Standard Library.
  */
 
@@ -25,9 +25,10 @@
 #include <boost/config.hpp>
 
 # if (defined(_YVALS) || defined(_CPPLIB_VER)) && !defined(__SGI_STL_PORT) && \
-     !defined(_STLPORT_VERSION) && !defined(__QNX__) && !defined(_VX_CPU) && !defined(__VXWORKS__)
+     !defined(_STLPORT_VERSION) && !defined(__QNX__) && !defined(_VX_CPU) && !defined(__VXWORKS__) \
+     && !(_MSVC_STL_VERSION >= 141)
      /**/
-     
+
 #include <boost/iostreams/detail/ios.hpp>
 
 #  define BOOST_IOSTREAMS_HAS_DINKUMWARE_FPOS

--- a/include/boost/iostreams/detail/config/fpos.hpp
+++ b/include/boost/iostreams/detail/config/fpos.hpp
@@ -26,7 +26,7 @@
 
 # if (defined(_YVALS) || defined(_CPPLIB_VER)) && !defined(__SGI_STL_PORT) && \
      !defined(_STLPORT_VERSION) && !defined(__QNX__) && !defined(_VX_CPU) && !defined(__VXWORKS__) \
-     && !(_MSVC_STL_VERSION >= 141)
+     && !(defined(BOOST_MSVC) && _MSVC_STL_VERSION >= 141)
      /**/
 
 #include <boost/iostreams/detail/ios.hpp>


### PR DESCRIPTION
Boost is attempting to use a function not in the standard, seekpos(),
guarded by this setting. Looks like Boost can use the standards
conforming interface for MSVC++ instead. It should work going
back effectively "forever" as far as MSVC++ is concerned, but this
guard applies the change only to 2017. It's possible there is a better
control in boost.config I missed.