### PR TITLE
Remove call to nonexistent member seekpos() of std::fpos

### DIFF
--- a/include/boost/iostreams/positioning.hpp
+++ b/include/boost/iostreams/positioning.hpp
@@ -93,7 +93,7 @@ inline stream_offset fpos_t_to_offset(std::fpos_t pos)
 inline std::fpos_t streampos_to_fpos_t(std::streampos pos)
 {
 #  if defined (_CPPLIB_VER) || defined(__IBMCPP__)
-    return pos.seekpos();
+    return pos;
 #  else
     return pos.get_fpos_t();
 #  endif


### PR DESCRIPTION
1. Boost-iostreams failed with error C2039: 'seekpos': is not a member of 'std::fpos<_Mbstatet>'.
2. See http://eel.is/c++draft/fpos -- to get to an offset you can convert to int; now there is no seekpos member.