### PR TITLE
add missing warning re-enabling include

### DIFF
--- a/include/boost/iostreams/detail/restrict_impl.hpp
+++ b/include/boost/iostreams/detail/restrict_impl.hpp
@@ -478,4 +478,6 @@ BOOST_IOSTREAMS_RESTRICT(T& t, stream_offset off, stream_offset len = -1)
 
 } } // End namespaces iostreams, boost.
 
+# include <boost/iostreams/detail/config/enable_warnings.hpp>
+
 #endif // #if !defined(BOOST_IOSTREAMS_RESTRICT_IMPL_HPP_INCLUDED) ...


### PR DESCRIPTION
fixes msvc warning C5032: "detected #pragma warning(push) with no corresponding #pragma warning(pop)"