### PR TITLE
LZMA threads

### DIFF
--- a/include/boost/iostreams/filter/lzma.hpp
+++ b/include/boost/iostreams/filter/lzma.hpp
@@ -175,6 +175,7 @@ private:
     void init_stream(bool compress);
     void*    stream_;         // Actual type: lzma_stream*.
     uint32_t level_;
+    uint32_t threads_;
 };
 
 //

--- a/include/boost/iostreams/filter/lzma.hpp
+++ b/include/boost/iostreams/filter/lzma.hpp
@@ -182,7 +182,7 @@ private:
 template<typename Alloc = std::allocator<char> >
 class lzma_compressor_impl : public lzma_base, public lzma_allocator<Alloc> {
 public:
-    lzma_compressor_impl(const lzma_params& = lzma::default_compression);
+    lzma_compressor_impl(const lzma_params& = lzma_params());
     ~lzma_compressor_impl();
     bool filter( const char*& src_begin, const char* src_end,
                  char*& dest_begin, char* dest_end, bool flush );
@@ -222,7 +222,7 @@ private:
 public:
     typedef typename base_type::char_type               char_type;
     typedef typename base_type::category                category;
-    basic_lzma_compressor( const lzma_params& = lzma::default_compression,
+    basic_lzma_compressor( const lzma_params& = lzma_params(),
                            std::streamsize buffer_size = default_device_buffer_size );
 };
 BOOST_IOSTREAMS_PIPABLE(basic_lzma_compressor, 1)

--- a/include/boost/iostreams/filter/lzma.hpp
+++ b/include/boost/iostreams/filter/lzma.hpp
@@ -171,7 +171,7 @@ private:
                   lzma::free_func,
                   void* derived );
     void*    stream_;         // Actual type: lzma_stream*.
-    uint32_t level;
+    uint32_t level_;
 };
 
 //

--- a/include/boost/iostreams/filter/lzma.hpp
+++ b/include/boost/iostreams/filter/lzma.hpp
@@ -170,7 +170,7 @@ private:
                   lzma::alloc_func,
                   lzma::free_func,
                   void* derived );
-    void*         stream_;         // Actual type: lzmadec_stream*.
+    void*    stream_;         // Actual type: lzma_stream*.
     uint32_t level;
 };
 

--- a/include/boost/iostreams/filter/lzma.hpp
+++ b/include/boost/iostreams/filter/lzma.hpp
@@ -87,10 +87,12 @@ const int null                               = 0;
 struct lzma_params {
 
     // Non-explicit constructor.
-    lzma_params( uint32_t level = lzma::default_compression )
+    lzma_params( uint32_t level = lzma::default_compression, uint32_t threads = 1 )
         : level(level)
+        , threads(threads)
         { }
     uint32_t level;
+    uint32_t threads;
 };
 
 //

--- a/include/boost/iostreams/filter/lzma.hpp
+++ b/include/boost/iostreams/filter/lzma.hpp
@@ -170,6 +170,7 @@ private:
                   lzma::alloc_func,
                   lzma::free_func,
                   void* derived );
+    void init_stream(bool compress);
     void*    stream_;         // Actual type: lzma_stream*.
     uint32_t level_;
 };

--- a/src/lzma.cpp
+++ b/src/lzma.cpp
@@ -18,6 +18,13 @@
 #include <boost/iostreams/detail/config/dyn_link.hpp>
 #include <boost/iostreams/filter/lzma.hpp>
 
+
+#ifndef BOOST_IOSTREAMS_LZMA_NO_MULTITHREADED
+    #if LZMA_VERSION < 50020002
+        #define BOOST_IOSTREAMS_LZMA_NO_MULTITHREADED
+    #endif
+#endif
+
 namespace boost { namespace iostreams {
 
 namespace lzma {
@@ -75,7 +82,7 @@ void lzma_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(int error)
 namespace detail {
 
 lzma_base::lzma_base()
-    : stream_(new lzma_stream), level_(lzma::default_compression)
+    : stream_(new lzma_stream), level_(lzma::default_compression), threads_(1)
     { }
 
 lzma_base::~lzma_base() { delete static_cast<lzma_stream*>(stream_); }
@@ -124,6 +131,13 @@ void lzma_base::do_init
 {
 
     level_ = p.level;
+    threads_ = p.threads;
+
+#ifndef BOOST_IOSTREAMS_LZMA_NO_MULTITHREADED
+    if (threads_ == 0) {
+        threads_ = lzma_cputhreads();
+    }
+#endif
 
     init_stream(compress);
 }
@@ -134,12 +148,23 @@ void lzma_base::init_stream(bool compress)
 
     memset(s, 0, sizeof(*s));
 
+#ifndef BOOST_IOSTREAMS_LZMA_NO_MULTITHREADED
+    const lzma_mt opt = {.flags = 0, .threads = threads_, .block_size = 0,
+                         .timeout = 1000, .preset = level_, .filters = nullptr,
+                         .check = LZMA_CHECK_CRC32};
+#endif
+
     lzma_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(
         compress ?
+#ifdef BOOST_IOSTREAMS_LZMA_NO_MULTITHREADED
             lzma_easy_encoder(s, level_, LZMA_CHECK_CRC32) :
+#else
+            lzma_stream_encoder_mt(s, &opt) :
+#endif
             lzma_stream_decoder(s, 100 * 1024 * 1024, LZMA_CONCATENATED)
     );
 }
+
 
 } // End namespace detail.
 

--- a/src/lzma.cpp
+++ b/src/lzma.cpp
@@ -113,13 +113,7 @@ void lzma_base::reset(bool compress, bool realloc)
     lzma_end(s);
     if (realloc)
     {
-        memset(s, 0, sizeof(*s));
-
-        lzma_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(
-            compress ?
-                lzma_easy_encoder(s, level_, LZMA_CHECK_CRC32) :
-                lzma_stream_decoder(s, 100 * 1024 * 1024, LZMA_CONCATENATED)
-        );
+        init_stream(compress);
     }
 }
 
@@ -128,14 +122,21 @@ void lzma_base::do_init
       lzma::alloc_func, lzma::free_func,
       void* )
 {
+
+    level_ = p.level;
+
+    init_stream(compress);
+}
+
+void lzma_base::init_stream(bool compress)
+{
     lzma_stream* s = static_cast<lzma_stream*>(stream_);
 
     memset(s, 0, sizeof(*s));
 
-    level_ = p.level;
     lzma_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(
         compress ?
-            lzma_easy_encoder(s, p.level, LZMA_CHECK_CRC32) :
+            lzma_easy_encoder(s, level_, LZMA_CHECK_CRC32) :
             lzma_stream_decoder(s, 100 * 1024 * 1024, LZMA_CONCATENATED)
     );
 }

--- a/src/lzma.cpp
+++ b/src/lzma.cpp
@@ -149,9 +149,7 @@ void lzma_base::init_stream(bool compress)
     memset(s, 0, sizeof(*s));
 
 #ifndef BOOST_IOSTREAMS_LZMA_NO_MULTITHREADED
-    const lzma_mt opt = {.flags = 0, .threads = threads_, .block_size = 0,
-                         .timeout = 1000, .preset = level_, .filters = nullptr,
-                         .check = LZMA_CHECK_CRC32};
+    const lzma_mt opt = { 0, threads_, 0, 1000, level_, NULL, LZMA_CHECK_CRC32 };
 #endif
 
     lzma_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(

--- a/src/lzma.cpp
+++ b/src/lzma.cpp
@@ -75,7 +75,7 @@ void lzma_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(int error)
 namespace detail {
 
 lzma_base::lzma_base()
-    : stream_(new lzma_stream), level(lzma::default_compression)
+    : stream_(new lzma_stream), level_(lzma::default_compression)
     { }
 
 lzma_base::~lzma_base() { delete static_cast<lzma_stream*>(stream_); }
@@ -117,7 +117,7 @@ void lzma_base::reset(bool compress, bool realloc)
 
         lzma_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(
             compress ?
-                lzma_easy_encoder(s, level, LZMA_CHECK_CRC32) :
+                lzma_easy_encoder(s, level_, LZMA_CHECK_CRC32) :
                 lzma_stream_decoder(s, 100 * 1024 * 1024, LZMA_CONCATENATED)
         );
     }
@@ -132,7 +132,7 @@ void lzma_base::do_init
 
     memset(s, 0, sizeof(*s));
 
-    level = p.level;
+    level_ = p.level;
     lzma_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(
         compress ?
             lzma_easy_encoder(s, p.level, LZMA_CHECK_CRC32) :


### PR DESCRIPTION
Enables multithreaded LZMA compression in Boost.iostreams.

I have tested the build and behavior on a range of Ubuntu and RHEL systems. I have tested the build and behavior of all numbered liblzma release versions in their git repo.

Unit testing doesn't cover:
 - That multiple threads are actually used when appropriate. Because how would I do that in a unit test?
 - Behavior on larger amounts of data (which liblzma deploys more threads on). Because it would slow down the execution of tests significantly.
 - That the build correctly detects liblzma's capabilities. Because this is a build issue.
 - That the build correctly uses BOOST_IOSTREAMS_LZMA_NO_MULTITHREADED macro. Because this is a build issue.