### PR TITLE
Add definition of file_descriptor_source::open()

### DIFF
--- a/include/boost/iostreams/device/file_descriptor.hpp
+++ b/include/boost/iostreams/device/file_descriptor.hpp
@@ -222,7 +222,8 @@ public:
 
     // open overload taking a Boost.Filesystem path
     template<typename Path>
-    void open(const Path& path, BOOST_IOS::openmode mode = BOOST_IOS::in);
+    void open(const Path& path, BOOST_IOS::openmode mode = BOOST_IOS::in)
+    { open(detail::path(path), mode); }
 private:
 
     // open overload taking a detail::path


### PR DESCRIPTION
This commit adds the missing definition of the overload of
file_descriptor_source::open() that accepts a boost::filesystem::path.