### PR TITLE
Avoid using deprecated headers to silence compiler warnings

### DIFF
--- a/include/boost/iostreams/detail/adapter/range_adapter.hpp
+++ b/include/boost/iostreams/detail/adapter/range_adapter.hpp
@@ -10,20 +10,20 @@
 
 #if defined(_MSC_VER)
 # pragma once
-#endif              
+#endif
 
 #include <algorithm>                             // min.
 #include <boost/assert.hpp>
 #include <cstddef>                               // ptrdiff_t.
 #include <iosfwd>                                // streamsize, streamoff.
-#include <boost/detail/iterator.hpp>             // boost::iterator_traits.
+#include <iterator>                              // iterator_traits.
 #include <boost/iostreams/categories.hpp>
 #include <boost/iostreams/detail/error.hpp>
 #include <boost/iostreams/positioning.hpp>
 #include <boost/mpl/if.hpp>
 #include <boost/throw_exception.hpp>
 #include <boost/type_traits/is_convertible.hpp>
-#include <boost/utility/enable_if.hpp>
+#include <boost/core/enable_if.hpp>
 
 // Must come last.
 #include <boost/iostreams/detail/config/disable_warnings.hpp>  // MSVC.
@@ -44,7 +44,7 @@ template<typename Mode, typename Range>
 class range_adapter {
 private:
     typedef typename Range::iterator                  iterator;
-    typedef boost::detail::iterator_traits<iterator>  iter_traits;
+    typedef std::iterator_traits<iterator>            iter_traits;
     typedef typename iter_traits::iterator_category   iter_cat;
 public:
     typedef typename Range::value_type                char_type;


### PR DESCRIPTION
The warnings are generated by `boost/detail/iterator.hpp`, which has been deprecated in favor of `<iterator>`.

Also, updated location of `enable_if.hpp`.
