### PR TITLE
Resolve visual studio warning C4127: conditional expression is constant.

### DIFF
--- a/include/boost/iostreams/detail/streambuf/indirect_streambuf.hpp
+++ b/include/boost/iostreams/detail/streambuf/indirect_streambuf.hpp
@@ -390,11 +390,18 @@ inline void indirect_streambuf<T, Tr, Alloc, Mode>::close_impl
         sync();
         setp(0, 0);
     }
+    #if defined(BOOST_MSVC)
+      #pragma warning(push)
+      #pragma warning(disable: 4127) // conditional expression is constant
+    #endif
     if ( !is_convertible<category, dual_use>::value ||
          is_convertible<Mode, input>::value == (which == BOOST_IOS::in) )
     {
         obj().close(which, next_);
     }
+    #if defined(BOOST_MSVC)
+      #pragma warning(pop)
+    #endif
 }
 
 //----------State changing functions------------------------------------------//


### PR DESCRIPTION
This resolves a warning in Visual Studio which is currently prevents using `boost::iostreams::stream<>` when this warning is enabled.

What seems to happen is that the first part of the expression is recognized as constant, but somehow the second part is not taken into account to see that the expression as a whole is not constant. Flipping the two around fixes the warning, but not the problem. In principle this code should still trigger the warning, because you probably want to know when a sub-expression in an if() statement is constant too. Because a constant sub-expression seems just as wrong a a constant full expression.

However, this seems to solve the warning without any changes to the logic, so this is a simple fix for now.
