### PR TITLE
Add missing include

### DIFF
--- a/include/boost/iostreams/detail/config/enable_warnings.hpp
+++ b/include/boost/iostreams/detail/config/enable_warnings.hpp
@@ -4,6 +4,7 @@
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt.)
 
 // See http://www.boost.org/libs/iostreams for documentation.
+#include <boost/config/workaround.hpp>
 
 #if defined(BOOST_MSVC)
 # pragma warning(pop)


### PR DESCRIPTION
This patch makes the header able to be built standalone, making possible C++ clang modules builds. @vgvassilev