### PR TITLE
Add missing include

### DIFF
--- a/include/boost/iostreams/detail/enable_if_stream.hpp
+++ b/include/boost/iostreams/detail/enable_if_stream.hpp
@@ -13,6 +13,7 @@
 #endif              
 
 #include <boost/config.hpp>                // BOOST_NO_SFINAE.
+#include <boost/config/workaround.hpp>
 #include <boost/utility/enable_if.hpp>                  
 #include <boost/iostreams/traits_fwd.hpp>  // is_std_io.
 


### PR DESCRIPTION
This patch makes the header able to be built standalone, making possible C++ clang modules builds.@vgvassilev