### PR TITLE
Fix compilation for PS4 libraries

### DIFF
--- a/include/boost/iostreams/detail/config/fpos.hpp
+++ b/include/boost/iostreams/detail/config/fpos.hpp
@@ -27,7 +27,7 @@
 # if (defined(_YVALS) || defined(_CPPLIB_VER)) && !defined(__SGI_STL_PORT) && \
      !defined(_STLPORT_VERSION) && !defined(__QNX__) && !defined(_VX_CPU) && !defined(__VXWORKS__) \
      && !((defined(BOOST_MSVC) || defined(BOOST_CLANG)) && _MSVC_STL_VERSION >= 141) \
-     && !defined(_LIBCPP_VERSION)
+     && !defined(_LIBCPP_VERSION) && !defined(__SCE__)
      /**/
 
 #include <boost/iostreams/detail/ios.hpp>


### PR DESCRIPTION
This is a simple compatibility fix for PS4 standard libraries. They don't have Dinkumware-like `fpos_t` implementation. The minimal code to reproduce problem/check solution:

```
#include <boost/iostreams/categories.hpp>
#include <boost/iostreams/operations.hpp>

class SourceMock
{
public:
	using char_type = char;
	using category = boost::iostreams::source_tag;
	std::streamsize read(char* /*buffer*/, std::streamsize /*size*/) { return 0; }
};

void foo()
{
	SourceMock source;
	char buffer[42];
	boost::iostreams::read(source, buffer, sizeof(buffer));
}
```

Output without fix looks like:
```
1>In file included from foo.ccp:2:
1>In file included from C:\.conan\7fa4fb\1\include\boost/iostreams/operations.hpp:16:
1>In file included from C:\.conan\7fa4fb\1\include\boost/iostreams/close.hpp:19:
1>In file included from C:\.conan\7fa4fb\1\include\boost/iostreams/detail/adapter/non_blocking_adapter.hpp:13:
1>In file included from C:\.conan\7fa4fb\1\include\boost/iostreams/seek.hpp:23:
1>C:\.conan\7fa4fb\1\include\boost/iostreams/positioning.hpp(52,10): error : no matching constructor for initialization of 'std::streampos' (aka 'fpos<_Mbstatet>')
1>C:\Program Files (x86)\SCE\ORBIS SDKs\7.000\target\include\iosfwd(48,2): note: candidate constructor not viable: no known conversion from 'boost::iostreams::stream_offset' (aka 'long') to 'fpos_t' for 2nd argument
1>C:\Program Files (x86)\SCE\ORBIS SDKs\7.000\target\include\iosfwd(43,2): note: candidate constructor not viable: allows at most single argument '_Off', but 2 arguments were provided
1>C:\Program Files (x86)\SCE\ORBIS SDKs\7.000\target\include\iosfwd(38,8): note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided
1>C:\Program Files (x86)\SCE\ORBIS SDKs\7.000\target\include\iosfwd(38,8): note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 2 were provided
```