### PR TITLE
Fix to compile with Visual C++ and /Zc:implicitNoexcept-.

### DIFF
--- a/include/boost/iostreams/filtering_stream.hpp
+++ b/include/boost/iostreams/filtering_stream.hpp
@@ -93,6 +93,9 @@ protected:
                  typename Chain::char_type, 
                  typename Chain::traits_type
             >::stream_type                                stream_type;
+
+    BOOST_DEFAULTED_FUNCTION(~filtering_stream_base() BOOST_NOEXCEPT, { })
+
     filtering_stream_base() : stream_type(0) { this->set_chain(&chain_); }
 private:
     void notify() { this->rdbuf(chain_.empty() ? 0 : &chain_.front()); }


### PR DESCRIPTION
Otherwise gets:
  Error C2694 'override': overriding virtual function
  has less restrictive exception specification than base class virtual
  member function 'base'

Similar changes are being made e.g.:
  https://github.com/boostorg/json/pull/636

See also, similar from me:
https://github.com/boostorg/format/pull/85