### PR TITLE
Add "const" versions of -> and * operators.

### DIFF
--- a/include/boost/iostreams/code_converter.hpp
+++ b/include/boost/iostreams/code_converter.hpp
@@ -283,7 +283,9 @@ public:
         // Direct device access.
 
     Device& operator*() { return detail::unwrap_direct(dev()); }
+    const Device& operator*() const { return detail::unwrap_direct(dev()); }
     Device* operator->() { return &detail::unwrap_direct(dev()); }
+    const Device* operator->() const { return &detail::unwrap_direct(dev()); }
 private:
     template<typename T> // Used for forwarding.
     void open_impl(const T& t BOOST_IOSTREAMS_CONVERTER_PARAMS()) 

--- a/include/boost/iostreams/detail/adapter/concept_adapter.hpp
+++ b/include/boost/iostreams/detail/adapter/concept_adapter.hpp
@@ -68,7 +68,9 @@ public:
     { BOOST_STATIC_ASSERT(!is_std_io<T>::value); }
 
     T& operator*() { return t_; }
+    const T& operator*() const { return t_; }
     T* operator->() { return &t_; }
+    const T* operator->() const { return &t_; }
 
     std::streamsize read(char_type* s, std::streamsize n)
     { return this->read(s, n, (basic_null_source<char_type>*) 0); }

--- a/include/boost/iostreams/detail/adapter/device_adapter.hpp
+++ b/include/boost/iostreams/detail/adapter/device_adapter.hpp
@@ -35,6 +35,7 @@ private:
 public:
     explicit device_adapter(param_type t) : t_(t) { }
     T& component() { return t_; }
+    const T& component() const { return t_; }
 
     void close() 
     {

--- a/include/boost/iostreams/detail/adapter/direct_adapter.hpp
+++ b/include/boost/iostreams/detail/adapter/direct_adapter.hpp
@@ -126,7 +126,9 @@ public:
         // Direct device access.
 
     Direct& operator*() { return d_; }
+    const Direct& operator*() const { return d_; }
     Direct* operator->() { return &d_; }
+    const Direct* operator->() const { return &d_; }
 #if BOOST_WORKAROUND(BOOST_MSVC, <= 1310)
 private:
     template<typename U>

--- a/include/boost/iostreams/detail/adapter/filter_adapter.hpp
+++ b/include/boost/iostreams/detail/adapter/filter_adapter.hpp
@@ -34,6 +34,7 @@ private:
 public:
     explicit filter_adapter(param_type t) : t_(t) { }
     T& component() { return t_; }
+    const T& component() const { return t_; }
 
     template<typename Device>
     void close(Device& dev) 

--- a/include/boost/iostreams/detail/broken_overload_resolution/stream.hpp
+++ b/include/boost/iostreams/detail/broken_overload_resolution/stream.hpp
@@ -107,7 +107,9 @@ public:
     void set_auto_close(bool close) { this->member.set_auto_close(close); }
     bool strict_sync() { return this->member.strict_sync(); }
     Device& operator*() { return *this->member; }
+    const Device& operator*() const { return *this->member; }
     Device* operator->() { return &*this->member; }
+    const Device* operator->() const { return &*this->member; }
 private:
     template<typename U0>
     void open_impl(mpl::false_, const U0& u0)

--- a/include/boost/iostreams/detail/broken_overload_resolution/stream_buffer.hpp
+++ b/include/boost/iostreams/detail/broken_overload_resolution/stream_buffer.hpp
@@ -117,7 +117,9 @@ public:
     }
 #endif // !BOOST_WORKAROUND(BOOST_MSVC, <= 1300) //---------------------------//
     T& operator*() { return *this->component(); }
+    const T& operator*() const { return *this->component(); }
     T* operator->() { return this->component(); }
+    const T* operator->() const { return this->component(); }
 private:
     template<typename U0>
     void open_impl(mpl::false_, const U0& u0)

--- a/include/boost/iostreams/detail/streambuf/direct_streambuf.hpp
+++ b/include/boost/iostreams/detail/streambuf/direct_streambuf.hpp
@@ -66,6 +66,7 @@ public: // stream needs access.
 
     // Declared in linked_streambuf.
     T* component() { return storage_.get(); }
+    const T* component() const { return storage_.get(); }
 protected:
     BOOST_IOSTREAMS_USING_PROTECTED_STREAMBUF_MEMBERS(base_type)
     direct_streambuf();

--- a/include/boost/iostreams/detail/streambuf/indirect_streambuf.hpp
+++ b/include/boost/iostreams/detail/streambuf/indirect_streambuf.hpp
@@ -72,6 +72,7 @@ public:
 
     // Declared in linked_streambuf.
     T* component() { return &*obj(); }
+    const T* component() const { return &*obj(); }
 protected:
     BOOST_IOSTREAMS_USING_PROTECTED_STREAMBUF_MEMBERS(base_type)
 
@@ -101,6 +102,7 @@ private:
     //----------Accessor functions--------------------------------------------//
 
     wrapper& obj() { return *storage_; }
+    const wrapper& obj() const { return *storage_; }
     streambuf_type* next() const { return next_; }
     buffer_type& in() { return buffer_.first(); }
     buffer_type& out() { return buffer_.second(); }

--- a/include/boost/iostreams/stream.hpp
+++ b/include/boost/iostreams/stream.hpp
@@ -150,8 +150,11 @@ public:
     void set_auto_close(bool close) { this->member.set_auto_close(close); }
     bool strict_sync() { return this->member.strict_sync(); }
     Device& operator*() { return *this->member; }
+    const Device& operator*() const { return *this->member; }
     Device* operator->() { return &*this->member; }
+    const Device* operator->() const { return &*this->member; }
     Device* component() { return this->member.component(); }
+    const Device* component() const { return this->member.component(); }
 private:
     void open_impl(const Device& dev BOOST_IOSTREAMS_PUSH_PARAMS()) // For forwarding.
     { 

--- a/include/boost/iostreams/stream_buffer.hpp
+++ b/include/boost/iostreams/stream_buffer.hpp
@@ -95,7 +95,9 @@ public:
                              BOOST_IOSTREAMS_PUSH_PARAMS,
                              BOOST_IOSTREAMS_PUSH_ARGS )
     T& operator*() { return *this->component(); }
+    const T& operator*() const { return *this->component(); }
     T* operator->() { return this->component(); }
+    const T* operator->() const { return this->component(); }
 private:
     void open_impl(const T& t BOOST_IOSTREAMS_PUSH_PARAMS())
         {   // Used for forwarding.


### PR DESCRIPTION
Also for the "component" and "obj" functions these use.
Fixes issue #134.