### PR TITLE
Turn off BOOST_IOSTREAMS_HAS_DINKUMWARE_FPOS for ICC on Windows

### DIFF
--- a/include/boost/iostreams/detail/config/fpos.hpp
+++ b/include/boost/iostreams/detail/config/fpos.hpp
@@ -26,7 +26,7 @@
 
 # if (defined(_YVALS) || defined(_CPPLIB_VER)) && !defined(__SGI_STL_PORT) && \
      !defined(_STLPORT_VERSION) && !defined(__QNX__) && !defined(_VX_CPU) && !defined(__VXWORKS__) \
-     && !((defined(BOOST_MSVC) || defined(BOOST_CLANG)) && _MSVC_STL_VERSION >= 141) \
+     && !((defined(BOOST_MSVC) || defined(BOOST_INTEL_WIN) || defined(BOOST_CLANG)) && _MSVC_STL_VERSION >= 141) \
      && !defined(_LIBCPP_VERSION)
      /**/
 


### PR DESCRIPTION
The Intel C++ Compiler on Windows uses the MSVC runtimes, and so has the same issue with std::fpos::seekpos begin deprecated. Add BOOST_INTEL_WIN to the preprocessor checks to exclude this combination as well.