### PR TITLE
Initialize zstd_base::level in constructor

### DIFF
--- a/src/zstd.cpp
+++ b/src/zstd.cpp
@@ -56,7 +56,7 @@ void zstd_error::check BOOST_PREVENT_MACRO_SUBSTITUTION(size_t error)
 namespace detail {
 
 zstd_base::zstd_base()
-    : cstream_(ZSTD_createCStream()), dstream_(ZSTD_createDStream()), in_(new ZSTD_inBuffer), out_(new ZSTD_outBuffer), eof_(0)
+    : cstream_(ZSTD_createCStream()), dstream_(ZSTD_createDStream()), in_(new ZSTD_inBuffer), out_(new ZSTD_outBuffer), eof_(0), level(zstd::default_compression)
     { }
 
 zstd_base::~zstd_base()


### PR DESCRIPTION
It does actually get initialized when the derived class calls
zstd_base::init but setting it in the constructor prevents static
analyzers from complaining.

A similar fix was made to `lzma_base` in 5692d3421962a0654f19d5c070431c7313fe4c92