### PR TITLE
chore: bump macos runner version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             os: ubuntu-20.04
           - toolset: clang
             cxxstd: "03,11,14,17,2a"
-            os: macos-10.15
+            os: macos-11
 
     runs-on: ${{matrix.os}}
 
@@ -156,9 +156,9 @@ jobs:
             shared: OFF
           - os: ubuntu-20.04
             shared: ON
-          - os: macos-10.15
+          - os: macos-11
             shared: OFF
-          - os: macos-10.15
+          - os: macos-11
             shared: ON
 
     runs-on: ${{matrix.os}}
@@ -211,9 +211,9 @@ jobs:
             shared: OFF
           - os: ubuntu-20.04
             shared: ON
-          - os: macos-10.15
+          - os: macos-11
             shared: OFF
-          - os: macos-10.15
+          - os: macos-11
             shared: ON
 
     runs-on: ${{matrix.os}}


### PR DESCRIPTION
GitHub Action is sunsetting the macOS 10.15 Actions runner. It will stop working intermittently until being completely removed by 2022-8-30: https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22