### PR TITLE
Fix clang -Wtautological-type-limit-compare warnings.

### DIFF
--- a/include/boost/iostreams/seek.hpp
+++ b/include/boost/iostreams/seek.hpp
@@ -81,6 +81,14 @@ struct seek_impl_basic_ios {
                                 BOOST_IOS::seekdir way,
                                 BOOST_IOS::openmode which )
     {
+#if defined(BOOST_CLANG)
+#   pragma clang diagnostic push
+#   if defined(__has_warning)
+#       if __has_warning("-Wtautological-type-limit-compare")
+#           pragma clang diagnostic ignored "-Wtautological-type-limit-compare"
+#       endif
+#   endif
+#endif
         if ( way == BOOST_IOS::beg &&
              ( off < integer_traits<std::streamoff>::const_min ||
                off > integer_traits<std::streamoff>::const_max ) )
@@ -90,6 +98,9 @@ struct seek_impl_basic_ios {
             return t.rdbuf()->pubseekoff(off, way, which);
         }
     }
+#if defined(BOOST_CLANG)
+#   pragma clang diagnostic pop
+#endif
 };
 
 template<>
@@ -108,6 +119,14 @@ struct seek_device_impl<streambuf_tag> {
                                 BOOST_IOS::seekdir way,
                                 BOOST_IOS::openmode which )
     {
+#if defined(BOOST_CLANG)
+#   pragma clang diagnostic push
+#   if defined(__has_warning)
+#       if __has_warning("-Wtautological-type-limit-compare")
+#           pragma clang diagnostic ignored "-Wtautological-type-limit-compare"
+#       endif
+#   endif
+#endif
         if ( way == BOOST_IOS::beg &&
              ( off < integer_traits<std::streamoff>::const_min ||
                off > integer_traits<std::streamoff>::const_max ) )
@@ -117,6 +136,9 @@ struct seek_device_impl<streambuf_tag> {
             return t.BOOST_IOSTREAMS_PUBSEEKOFF(off, way, which);
         }
     }
+#if defined(BOOST_CLANG)
+#   pragma clang diagnostic pop
+#endif
 };
 
 template<>


### PR DESCRIPTION
```
In file included from /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/iostreams/filtering_streambuf.hpp:17: In file included from /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/iostreams/chain.hpp:28: In file included from /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/iostreams/detail/push.hpp:24: In file included from /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/iostreams/detail/resolve.hpp:19: In file included from /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/iostreams/detail/adapter/mode_adapter.hpp:24: In file included from /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/iostreams/operations.hpp:16: In file included from /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/iostreams/close.hpp:19: In file included from /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/iostreams/detail/adapter/non_blocking_adapter.hpp:13: /data/mwrep/res/osp/Boost/23-0-0-0/include/boost/iostreams/seek.hpp:86:20: error: result of comparison 'boost::iostreams::stream_offset' (aka 'long') > 9223372036854775807 is always
 false [-Werror,-Wtautological-type-limit-compare]
               off > integer_traits<std::streamoff>::const_max ) )
               ~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/mwrep/res/osp/Boost/23-0-0-0/include/boost/iostreams/seek.hpp:85:20: error: result of comparison 'boost::iostreams::stream_offset' (aka 'long') < -9223372036854775808 is always false [-Werror,-Wtautological-type-limit-compare]
             ( off < integer_traits<std::streamoff>::const_min ||
               ~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/mwrep/res/osp/Boost/23-0-0-0/include/boost/iostreams/seek.hpp:113:20: error: result of comparison 'boost::iostreams::stream_offset' (aka 'long') > 9223372036854775807 is always false [-Werror,-Wtautological-type-limit-compare]
               off > integer_traits<std::streamoff>::const_max ) )
               ~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/mwrep/res/osp/Boost/23-0-0-0/include/boost/iostreams/seek.hpp:112:20: error: result of comparison 'boost::iostreams::stream_offset' (aka 'long') < -9223372036854775808 is always false [-Werror,-Wtautological-type-limit-compare]
             ( off < integer_traits<std::streamoff>::const_min ||
               ~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
4 errors generated.
```

Note: I am not sure this check on the offset is valid in the first place, I don't know how possible it is that `stream_offset` is a different type than `std::streamoff` in which case this check is totally pointless as always false.