### PR TITLE
Fix typos in zstd_decompressor_impl comment

### DIFF
--- a/include/boost/iostreams/filter/zstd.hpp
+++ b/include/boost/iostreams/filter/zstd.hpp
@@ -183,8 +183,8 @@ public:
 };
 
 //
-// Template name: zstd_compressor_impl
-// Description: Model of C-Style Filte implementing decompression by
+// Template name: zstd_decompressor_impl
+// Description: Model of C-Style Filter implementing decompression by
 //      delegating to the zstd function inflate.
 //
 template<typename Alloc = std::allocator<char> >


### PR DESCRIPTION
This MR fixes two typos in the comment for `zstd_decompressor_impl` in `include/boost/iostreams/filter/zstd.hpp`.