### PR TITLE
Remove redundant copy constructor.

### DIFF
--- a/include/boost/iostreams/device/mapped_file.hpp
+++ b/include/boost/iostreams/device/mapped_file.hpp
@@ -131,11 +131,6 @@ struct basic_mapped_file_params
     template<typename PathT>
     explicit basic_mapped_file_params(const PathT& p) : path(p) { }
 
-    // Copy constructor
-    basic_mapped_file_params(const basic_mapped_file_params& other)
-        : base_type(other), path(other.path)
-        { }
-
     // Templated copy constructor
     template<typename PathT>
     basic_mapped_file_params(const basic_mapped_file_params<PathT>& other)


### PR DESCRIPTION
Since C++11, a user-declared copy constructor deprecates the copy assignment operator.

This change allows clean compilation with the -Wdeprecated-copy/-Wdeprecated-copy-with-user-provided-ctor flag.