### PR TITLE
Disable msvc warning that can occur under some versions+settings

### DIFF
--- a/include/boost/iostreams/detail/config/disable_warnings.hpp
+++ b/include/boost/iostreams/detail/config/disable_warnings.hpp
@@ -15,6 +15,7 @@
 # pragma warning(disable:4224)    // Parameter previously defined as type.
 # pragma warning(disable:4244)    // Conversion: possible loss of data.
 # pragma warning(disable:4512)    // Assignment operator could not be generated.
+# pragma warning(disable:4702)    // Unreachable code.
 # pragma warning(disable:4706)    // Assignment within conditional expression.
 # if BOOST_WORKAROUND(BOOST_MSVC, >= 1400)
 #  pragma warning(disable:6334)   // sizeof applied to an expression with an operator.


### PR DESCRIPTION
This warning has been observed under more than one version. One specific example, as described in issue #138, is on indirect_streambuf.hpp(440) when Whole Program Optimization is off. In this case, the line before is seen by the optimizer as always throwing for particular instantiations of the template, and therefore the line in question is flagged as not reachable.

MSVC team has stated this is is expected behavior. (https://developercommunity.visualstudio.com/t/Unexpected-C4702-Unreachable-code-in-boo/10410775)

This is a simple and hopefully good-enough fix.