### PR TITLE
cmake:add pkgconfig usage if find_package failed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,25 +11,53 @@ add_library(boost_iostreams
   src/mapped_file.cpp
 )
 
-function(boost_iostreams_option name description package version found target) # sources...
-
-  find_package(${package} ${version} QUIET)
-
-  if(${found} AND TARGET ${target})
-
-    option(${name} ${description} ON)
-
-  else()
-
-    option(${name} ${description} OFF)
-
-  endif()
+function(boost_iostreams_option name description package version found target pkgconfig_name pkgconfig_target) # sources...
 
   if(${name})
 
-    find_package(${package} ${version} REQUIRED)
-    target_sources(boost_iostreams PRIVATE ${ARGN})
-    target_link_libraries(boost_iostreams PRIVATE ${target})
+    find_package(${package} ${version} QUIET)
+    
+    if(${found} AND TARGET ${target})
+    
+      option(${name} ${description} ON)
+      target_sources(boost_iostreams PRIVATE ${ARGN})
+      target_link_libraries(boost_iostreams PRIVATE ${target})
+    
+    else()
+
+      find_package(PkgConfig REQUIRED)
+      pkg_check_modules(${pkgconfig_name} GLOBAL IMPORTED_TARGET REQUIRED ${pkgconfig_name})
+
+      if(TARGET ${pkgconfig_target})
+
+        target_sources(boost_iostreams PRIVATE ${ARGN})
+        target_link_libraries(boost_iostreams PRIVATE ${pkgconfig_target})
+      
+      else()
+        
+        message(FATAL_ERROR "Option ${boost_iostreams_option} was turned on, but no .cmake config or .pc files related to corresponding library wasn't found. Are those libraries installed?")
+
+      endif()
+    endif()
+  elseif(DEFINED ${name} AND NOT ${name})
+    
+    option(${name} ${description} OFF)
+
+  else()
+
+    find_package(${package} ${version} QUIET)
+    
+    if(${found} AND TARGET ${target})
+
+      option(${name} ${description} ON)
+      target_sources(boost_iostreams PRIVATE ${ARGN})
+      target_link_libraries(boost_iostreams PRIVATE ${target})
+
+    else()
+
+      option(${name} ${description} OFF)
+
+    endif()
 
   endif()
 
@@ -39,10 +67,10 @@ endfunction()
 set(BOOST_IOSTREAMS_ZSTD_TARGET "zstd::libzstd_shared" CACHE STRING "Target name for Zstd (zstd::libzstd_shared, zstd::libzstd_static)")
 set_property(CACHE BOOST_IOSTREAMS_ZSTD_TARGET PROPERTY STRINGS "zstd::libzstd_shared" "zstd::libzstd_static")
 
-boost_iostreams_option(BOOST_IOSTREAMS_ENABLE_ZLIB "Boost.Iostreams: Enable ZLIB support" ZLIB "" ZLIB_FOUND ZLIB::ZLIB src/zlib.cpp src/gzip.cpp)
-boost_iostreams_option(BOOST_IOSTREAMS_ENABLE_BZIP2 "Boost.Iostreams: Enable BZip2 support" BZip2 "" BZIP2_FOUND BZip2::BZip2 src/bzip2.cpp)
-boost_iostreams_option(BOOST_IOSTREAMS_ENABLE_LZMA "Boost.Iostreams: Enable LZMA support" LibLZMA "" LIBLZMA_FOUND LibLZMA::LibLZMA src/lzma.cpp)
-boost_iostreams_option(BOOST_IOSTREAMS_ENABLE_ZSTD "Boost.Iostreams: Enable Zstd support" zstd "1.0" zstd_FOUND ${BOOST_IOSTREAMS_ZSTD_TARGET} src/zstd.cpp)
+boost_iostreams_option(BOOST_IOSTREAMS_ENABLE_ZLIB "Boost.Iostreams: Enable ZLIB support" ZLIB "" ZLIB_FOUND ZLIB::ZLIB zlib PkgConfig::zlib src/zlib.cpp src/gzip.cpp)
+boost_iostreams_option(BOOST_IOSTREAMS_ENABLE_BZIP2 "Boost.Iostreams: Enable BZip2 support" BZip2 "" BZIP2_FOUND BZip2::BZip2 bzip2 PkgConfig::bzip2 src/bzip2.cpp)
+boost_iostreams_option(BOOST_IOSTREAMS_ENABLE_LZMA "Boost.Iostreams: Enable LZMA support" LibLZMA "" LIBLZMA_FOUND LibLZMA::LibLZMA liblzma PkgConfig::liblzma src/lzma.cpp)
+boost_iostreams_option(BOOST_IOSTREAMS_ENABLE_ZSTD "Boost.Iostreams: Enable Zstd support" zstd "1.0" zstd_FOUND ${BOOST_IOSTREAMS_ZSTD_TARGET} libzstd PkgConfig::libzstd src/zstd.cpp)
 
 include(CheckCXXSourceCompiles)
 


### PR DESCRIPTION
It's related to the situation with zstd: it has homebrew makefiles as default buildsystem. Thus, they use .pc files. Yes, they have CMake support, but downstream distros, like Gentoo, use Meson, which doesn't produce .cmake config files. Thus, I've added the mechanism for looking for a .pc files of corresponding libraries.