### PR TITLE
bugfix: 修复visualstudio2022编译问题

### DIFF
--- a/include/boost/iostreams/positioning.hpp
+++ b/include/boost/iostreams/positioning.hpp
@@ -92,11 +92,14 @@ inline stream_offset fpos_t_to_offset(std::fpos_t pos)
 // Extracts the member _Fpos from a std::fpos
 inline std::fpos_t streampos_to_fpos_t(std::streampos pos)
 {
-#  if defined (_CPPLIB_VER) || defined(__IBMCPP__)
+#if defined(_MSC_VER) && (_MSC_VER >= 1930)
+  // For MSVC 2022 and later
+  return static_cast<std::fpos_t>(pos);
+#elif defined(_CPPLIB_VER) || defined(__IBMCPP__)
     return pos.seekpos();
-#  else
+#else
     return pos.get_fpos_t();
-#  endif
+#endif
 }
 
 inline stream_offset position_to_offset(std::streampos pos)


### PR DESCRIPTION
在新的C++标准中允许std::streampos直接转换成std::fpos_t，并且在visual studio2022中seekpos的定义被删除，导致编译失败。