### PR TITLE
Remove dependency on Boost.random.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,6 @@ target_link_libraries(boost_iostreams
     Boost::iterator
     Boost::mpl
     Boost::preprocessor
-    Boost::random
     Boost::range
     Boost::regex
     Boost::smart_ptr

--- a/build.jam
+++ b/build.jam
@@ -18,7 +18,6 @@ constant boost_dependencies :
     /boost/mpl//boost_mpl
     /boost/numeric_conversion//boost_numeric_conversion
     /boost/preprocessor//boost_preprocessor
-    /boost/random//boost_random
     /boost/range//boost_range
     /boost/regex//boost_regex
     /boost/smart_ptr//boost_smart_ptr

--- a/include/boost/iostreams/filter/test.hpp
+++ b/include/boost/iostreams/filter/test.hpp
@@ -24,12 +24,7 @@
 #include <iterator>
 #include <string>
 #include <vector>
-#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564)) && \
-    !BOOST_WORKAROUND(__MWERKS__, <= 0x3003) \
-    /**/
-# include <boost/random/linear_congruential.hpp>
-# include <boost/random/uniform_smallint.hpp>
-#endif
+#include <random>
 #include <boost/iostreams/categories.hpp>
 #include <boost/iostreams/compose.hpp>
 #include <boost/iostreams/copy.hpp>
@@ -64,21 +59,12 @@ BOOST_IOSTREAMS_BOOL_TRAIT_DEF(is_string, std::basic_string, 3)
 
 const std::streamsize default_increment = 5;
 
-#if !BOOST_WORKAROUND(BOOST_BORLANDC, BOOST_TESTED_AT(0x564)) && \
-    !BOOST_WORKAROUND(__MWERKS__, <= 0x3003) \
-    /**/
-    std::streamsize rand(std::streamsize inc)
-    {
-        static rand48                random_gen;
-        static uniform_smallint<int> random_dist(0, static_cast<int>(inc));
-        return random_dist(random_gen);
-    }
-#else
-    std::streamsize rand(std::streamsize inc) 
-    { 
-        return (std::rand() * inc + 1) / RAND_MAX; 
-    }
-#endif
+std::streamsize rand(std::streamsize inc)
+{
+    static std::mt19937                       random_gen;
+    static std::uniform_int_distribution<int> random_dist(0, static_cast<int>(inc));
+    return random_dist(random_gen);
+}
 
 class non_blocking_source {
 public:


### PR DESCRIPTION
Boost.iostreams now requires C++11, so normally a <random> implementation shall exists in the compiling toolchain, so use this instead of the Boost implementation.

This allows to no longer depend explicitly on libboost_random.so, which is now the case with the recent modular works (see other case of these extra dependencies being added with modular changes in https://github.com/boostorg/regex/issues/253 or
https://github.com/boostorg/system/issues/132)